### PR TITLE
 Small enhancements to BlockNot.h

### DIFF
--- a/examples/ResetAll/ResetAll.ino
+++ b/examples/ResetAll/ResetAll.ino
@@ -54,7 +54,7 @@ void loop()
         printTime(3);
     }
     
-    if (resetTimer.TRIGGERED) {
+    if (resetTimer.TRIGGERED_ON_DURATION) {
         Serial.println(F("\n\n---- Reset all timers ----\n"));
         RESET_TIMERS;
     }

--- a/src/BlockNot.h
+++ b/src/BlockNot.h
@@ -42,8 +42,6 @@ public:
     This library is very simple as libraries go. Each method in the library is described in README.md
     see: https://github.com/EasyG0ing1/BlockNot for complete documentation.
 */
-    static BlockNot* firstTimer;
-    static BlockNot* currentTimer;
 
     BlockNot() { 
         addToTimerList();
@@ -147,7 +145,8 @@ public:
         resetTimer( newStartTime );
     }
 
-    BlockNot* getNextTimer() { return nextTimer; }
+    static BlockNot* getFirstTimer() { return firstTimer; }
+    BlockNot* getNextTimer()         { return nextTimer; }
 
 private:
     /*
@@ -165,9 +164,11 @@ private:
 
     bool baseUnits = MILLISECONDS;
 
+    static BlockNot* firstTimer;
+    static BlockNot* currentTimer;
     BlockNot* nextTimer;
 
-void resetTimer( const unsigned long newStartTime ) {
+    void resetTimer( const unsigned long newStartTime ) {
         if (timerEnabled) {
             startTime = newStartTime;
             onceTriggered = false;
@@ -204,22 +205,23 @@ void resetTimer( const unsigned long newStartTime ) {
         if ( firstTimer == nullptr ) {
             firstTimer = currentTimer = this;
         } else {
-            currentTimer->setNextTimer( this );
+            currentTimer->nextTimer = this;
             currentTimer = this;
         }
-        this->setNextTimer( nullptr );
+        this->nextTimer = nullptr;
     }
 
-    void setNextTimer( BlockNot* timer ) { nextTimer = timer; }
 };
 
 void resetAllTimers( const unsigned long newStartTime = millis() ) {
-    BlockNot* timer = BlockNot::firstTimer;
+    BlockNot* timer = BlockNot::getFirstTimer();
     while( timer != nullptr ) {
         timer->BlockNot::reset( newStartTime );
         timer = timer->BlockNot::getNextTimer();
     }
 }
+
+void resetAllTimers( BlockNot* timer ) { resetAllTimers( timer->BlockNot::getStartTime() ); }
 
 BlockNot* BlockNot::firstTimer   = nullptr;
 BlockNot* BlockNot::currentTimer = nullptr;


### PR DESCRIPTION
Hi Mike,

Have reviewed my code for resetAllTimers, and there are a couple small changes that should make the code more robust/safe. 

Changes are not impacting existing functionality. They incorporate:

- making firstTimer and currentTimer variables "private", to prevent external modification
- addition of getFirstTimer() to safely access the firstTimer variable externally by resetAllTimers()
- streamlining of addToTimerList() to eliminate setNextTimer() function
- add overload to resetAllTimers(), so that newStartTime can be derived from an existing timer, rather than having to specify a value
- in the example sketch ResetAll.ino: Change resetTimer.TRIGGERED to resetTimer.TRIGGERED_ON_DURATION in order to prevent timer drift on slower boards

No urgency, maybe take a look next time you are publishing a new release.

Thanks,

Michael
