### PR TITLE
Resolve compiler warnings by ensuring proper variable initialization

### DIFF
--- a/src/BlockNot.cpp
+++ b/src/BlockNot.cpp
@@ -243,7 +243,7 @@ bool BlockNot::triggered(bool resetOption) {
 
 bool BlockNot::triggeredOnDuration(bool allMissed) {
     bool triggered = hasTriggered();
-    unsigned long missedDurations;
+    unsigned long missedDurations = 0;
     unsigned long newStartTime;
     if (triggered) {
         switch(baseUnits) {
@@ -532,8 +532,8 @@ unsigned long BlockNot::timeSinceReset() {
 }
 
 bool BlockNot::hasTriggered() {
-    bool triggered;
-    long sinceReset = timeSinceReset();
+    bool triggered = false;
+    unsigned long sinceReset = timeSinceReset();
     switch(baseUnits) {
         case MICROSECONDS:
             triggered = sinceReset >= (unsigned long) duration.micros;
@@ -551,7 +551,7 @@ bool BlockNot::hasTriggered() {
 }
 
 bool BlockNot::hasNotTriggered() {
-    bool notTriggered;
+    bool notTriggered = false;
     switch(baseUnits) {
         case MICROSECONDS:
             notTriggered = timeSinceReset() < (unsigned long) duration.micros;

--- a/src/BlockNot.h
+++ b/src/BlockNot.h
@@ -191,7 +191,7 @@ private:
     bool onceTriggered = false;
 
     union cTime {
-        double seconds;
+        double seconds = 0.0;
 
         class milli_t {
             double seconds;


### PR DESCRIPTION
Got some compiler warnings when using this library which were all due to variable use before initialization.